### PR TITLE
Fix key directory issue

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -5,22 +5,23 @@ declare(strict_types=1);
 namespace PharIo\ComposerDistributor\Config;
 
 use PharIo\ComposerDistributor\FileList;
+use RuntimeException;
 
 class Config
 {
     /** @var string */
     private $package;
 
-    /** @var \SplFileInfo|null */
+    /** @var string|null */
     private $keyDirectory;
 
     /** @var \PharIo\ComposerDistributor\FileList */
     private $phars;
 
-    public function __construct(string $package, FileList $phars, ?\SplFileInfo $keyDir = null)
+    public function __construct(string $package, FileList $phars, ?string $keyDir = null)
     {
         if (strpos($package, '/') === false) {
-            throw new \RuntimeException('Invalid package name');
+            throw new RuntimeException('Invalid package name');
         }
         $this->package      = $package;
         $this->phars        = $phars;
@@ -32,7 +33,7 @@ class Config
         return $this->package;
     }
 
-    public function keyDirectory(): ?\SplFileInfo
+    public function keyDirectory(): ?string
     {
         return $this->keyDirectory;
     }

--- a/src/Config/Mapper.php
+++ b/src/Config/Mapper.php
@@ -8,7 +8,6 @@ use DOMDocument;
 use PharIo\ComposerDistributor\File;
 use PharIo\ComposerDistributor\FileList;
 use PharIo\ComposerDistributor\Url;
-use RuntimeException;
 
 class Mapper
 {
@@ -31,7 +30,6 @@ class Mapper
     {
         $original    = \libxml_use_internal_errors(true);
         $xsdFilename = __DIR__ . '/../../distributor.xsd';
-        $errors      = [];
 
         if ($this->document->schemaValidate($xsdFilename)) {
             return;
@@ -66,12 +64,12 @@ class Mapper
         return new FileList(...$phars);
     }
 
-    private function createKeyDir(): ?\SplFileInfo
+    private function createKeyDir(): ?string
     {
         $root = $this->document->documentElement;
 
         return $root->hasAttribute('keyDirectory')
-            ? new \SplFileInfo($root->getAttribute('keyDirectory'))
+            ? $root->getAttribute('keyDirectory')
             : null;
     }
 }

--- a/src/FileList.php
+++ b/src/FileList.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Copyright by the ComposerDistributor-Team
- *
- * Licenses under the MIT-license. For details see the included file LICENSE.md
- */
 
 declare(strict_types=1);
 

--- a/src/IteratorImplementation.php
+++ b/src/IteratorImplementation.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Copyright by the ComposerDistributor-Team
- *
- * Licenses under the MIT-license. For details see the included file LICENSE.md
- */
 
 declare(strict_types=1);
 

--- a/src/KeyDirectory.php
+++ b/src/KeyDirectory.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Copyright by the ComposerDistributor-Team
- *
- * Licenses under the MIT-license. For details see the included file LICENSE.md
- */
 
 declare(strict_types=1);
 

--- a/src/KeyNotFound.php
+++ b/src/KeyNotFound.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PharIo\ComposerDistributor;
+
+use RuntimeException;
+
+final class KeyNotFound extends RuntimeException
+{
+    public static function fromInvalidPath(string $path) : self
+    {
+        return new self(sprintf('Invalid key location "%s"', $path));
+    }
+}

--- a/src/NoSemanticVersioning.php
+++ b/src/NoSemanticVersioning.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Copyright by the ComposerDistributor-Team
- *
- * Licenses under the MIT-license. For details see the included file LICENSE.md
- */
 
 declare(strict_types=1);
 
@@ -13,7 +8,7 @@ use RuntimeException;
 
 final class NoSemanticVersioning extends RuntimeException
 {
-    public static function fromversionString(string $version) : self
+    public static function fromVersionString(string $version) : self
     {
         return new self(sprintf('The version string "%s" does not follow semantic versioning', $version));
     }

--- a/src/PackageVersion.php
+++ b/src/PackageVersion.php
@@ -1,17 +1,6 @@
 <?php
-/**
- * Copyright by the ComposerDistributor-Team
- *
- * Licenses under the MIT-license. For details see the included file LICENSE.md
- */
 
 declare(strict_types=1);
-
-/**
- * Copyright Andreas Heigl <andreas@heigl.org>
- *
- * Licenses under the MIT-license. For details see the included file LICENSE.md
- */
 
 namespace PharIo\ComposerDistributor;
 
@@ -29,10 +18,13 @@ use function version_compare;
 
 final class PackageVersion
 {
+    /** @var string */
     private $name;
 
+    /** @var string */
     private $versionString;
 
+    /** @var \PharIo\ComposerDistributor\SemanticVersion|null */
     private $semver;
 
     private function __construct(string $name, string $versionString)

--- a/src/PluginBase.php
+++ b/src/PluginBase.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Copyright by the ComposerDistributor-Team
- *
- * Licenses under the MIT-license. For details see the included file LICENSE.md
- */
 
 declare(strict_types=1);
 

--- a/src/SemanticVersion.php
+++ b/src/SemanticVersion.php
@@ -53,16 +53,16 @@ final class SemanticVersion
 
         $b = explode('.', $a[0]);
         if (!$b) {
-            throw NoSemanticVersioning::fromversionString($originalVersionString);
+            throw NoSemanticVersioning::fromVersionString($originalVersionString);
         }
 
         if (3 !== count($b)) {
-            throw NoSemanticVersioning::fromversionString($originalVersionString);
+            throw NoSemanticVersioning::fromVersionString($originalVersionString);
         }
 
         foreach ($b as $i) {
             if (!is_numeric($i)) {
-                throw NoSemanticVersioning::fromversionString($originalVersionString);
+                throw NoSemanticVersioning::fromVersionString($originalVersionString);
             }
         }
 

--- a/src/Service/Download.php
+++ b/src/Service/Download.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Copyright by the ComposerDistributor-Team
- *
- * Licenses under the MIT-license. For details see the included file LICENSE.md
- */
 
 declare(strict_types=1);
 

--- a/src/Service/Installer.php
+++ b/src/Service/Installer.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Copyright by the ComposerDistributor-Team
- *
- * Licenses under the MIT-license. For details see the included file LICENSE.md
- */
 
 declare(strict_types=1);
 
@@ -63,7 +58,7 @@ final class Installer
 
         foreach ($fileList->getList() as $file) {
             $this->io->write(sprintf(
-                'downloading Artifact in version %2$s from %1$s',
+                '    Downloading artifact in version %2$s from %1$s',
                 $versionReplacer->replace($file->pharUrl()->toString()),
                 $packageVersion->fullVersion()
             ));
@@ -71,19 +66,18 @@ final class Installer
             $pharLocation = $this->downloadPhar($versionReplacer, $file);
 
             if (!$file->signatureUrl()) {
-                $this->io->write(sprintf(
-                    "No digital Signature found! Use this file with care!"
-                ));
+                $this->io->write('    No digital signature found! Use this file with care!');
                 continue;
             }
 
             $signatureLocation = $this->downloadSignature($versionReplacer, $file);
             $this->verifyPharWithSignature($pharLocation, $signatureLocation);
+            $this->io->write('    PHAR signature successfully verified');
             unlink($signatureLocation->getPathname());
         }
     }
 
-    private function downloadPhar(VersionConstraintReplacer $versionReplacer, File $file): \SplFileInfo
+    private function downloadPhar(VersionConstraintReplacer $versionReplacer, File $file): SplFileInfo
     {
         $binDir       = $this->event->getComposer()->getConfig()->get('bin-dir');
         $download     = new Download(Url::fromString(
@@ -102,7 +96,7 @@ final class Installer
         return $pharLocation;
     }
 
-    private function downloadSignature(VersionConstraintReplacer $versionReplacer, File $file): \SplFileInfo
+    private function downloadSignature(VersionConstraintReplacer $versionReplacer, File $file): SplFileInfo
     {
         $downloadSignature = new Download(Url::fromString(
             $versionReplacer->replace($file->signatureUrl()->toString())

--- a/src/Service/Verify.php
+++ b/src/Service/Verify.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Copyright by the ComposerDistributor-Team
- *
- * Licenses under the MIT-license. For details see the included file LICENSE.md
- */
 
 declare(strict_types=1);
 

--- a/src/Service/VersionConstraintReplacer.php
+++ b/src/Service/VersionConstraintReplacer.php
@@ -8,7 +8,7 @@ use PharIo\ComposerDistributor\PackageVersion;
 
 final class VersionConstraintReplacer
 {
-    /** @var \PharIo\ComposerDistributor\PackageVersion  */
+    /** @var \PharIo\ComposerDistributor\PackageVersion */
     private $versionConstraint;
 
     public function __construct(PackageVersion $versionConstraint)

--- a/src/SomebodyElsesProblem.php
+++ b/src/SomebodyElsesProblem.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Copyright by the ComposerDistributor-Team
- *
- * Licenses under the MIT-license. For details see the included file LICENSE.md
- */
 
 declare(strict_types=1);
 

--- a/src/Url.php
+++ b/src/Url.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Copyright by the ComposerDistributor-Team
- *
- * Licenses under the MIT-license. For details see the included file LICENSE.md
- */
 
 declare(strict_types=1);
 
@@ -14,20 +9,28 @@ use function parse_url;
 
 final class Url
 {
+    /** @var string */
     private $scheme;
 
+    /** @var string */
     private $host;
 
+    /** @var int */
     private $port;
 
+    /** @var string */
     private $user;
 
+    /** @var string */
     private $password;
 
+    /** @var string */
     private $path;
 
+    /** @var string */
     private $query;
 
+    /** @var string */
     private $fragment;
 
     private function __construct(


### PR DESCRIPTION
The issue with the `keyDirectory` was the path resolving.
The config is not validating the path to the `keyDirectory` so I switched the return type back to string.
The validation is now happening during the `KeyDirectory` creation.
For this I added the new `KeyNotFound` exception.
I added some extra whitespaces to the download and verification output so it is better aligned with the composer output.

There are also some type hint additions and some file header removals.