### PR TITLE
Make sure config is loaded

### DIFF
--- a/src/ConfiguredMediator.php
+++ b/src/ConfiguredMediator.php
@@ -82,11 +82,11 @@ abstract class ConfiguredMediator extends PluginBase
         if (is_file($pharLocation)) {
             if (!is_writable($pharLocation)) {
                 $this->io->write(
-                    sprintf('    Can not remove phar \'%1$s\' (insufficient permissions)', $phar->pharName())
+                    sprintf('  - Can not remove phar \'%1$s\' (insufficient permissions)', $phar->pharName())
                 );
                 return;
             }
-            $this->io->write(sprintf('    Removing phar \'%1$s\'', $phar->pharName()));
+            $this->io->write(sprintf('  - Removing phar \'%1$s\'', $phar->pharName()));
             unlink($pharLocation);
         }
     }

--- a/src/Service/Installer.php
+++ b/src/Service/Installer.php
@@ -58,7 +58,7 @@ final class Installer
 
         foreach ($fileList->getList() as $file) {
             $this->io->write(sprintf(
-                '    Downloading artifact in version %2$s from %1$s',
+                '  - Downloading artifact in version %2$s from %1$s',
                 $versionReplacer->replace($file->pharUrl()->toString()),
                 $packageVersion->fullVersion()
             ));
@@ -66,13 +66,13 @@ final class Installer
             $pharLocation = $this->downloadPhar($versionReplacer, $file);
 
             if (!$file->signatureUrl()) {
-                $this->io->write('    No digital signature found! Use this file with care!');
+                $this->io->write('  - No digital signature found! Use this file with care!');
                 continue;
             }
 
             $signatureLocation = $this->downloadSignature($versionReplacer, $file);
             $this->verifyPharWithSignature($pharLocation, $signatureLocation);
-            $this->io->write('    PHAR signature successfully verified');
+            $this->io->write('  - PHAR signature successfully verified');
             unlink($signatureLocation->getPathname());
         }
     }


### PR DESCRIPTION
Since all external dependencies are removed before uninstall is
called we have to make sure that everything required to handle
the uninstallation is loaded upfront.

The problem was that to read the _internal_ `captainhook-phar` `distributor.xml` the _external_ `composer-distributor` `Loader::loadFile` is used. And since composer removes all _external_ packages before calling `uninstall` we had to make sure all contents is loaded into memory before the files get removed.

Moving the config loading to the constructor of the plugin fixed the issue, since the plugin is loaded right at the start of the composer execution.