### PR TITLE
Feature/error handling

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,19 +1,30 @@
-Copyright ComposerDistributor-Team
+Phar.io - Composer Distributor
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
+Copyright (c) 2020 Arne Blankerts <arne@blankerts.de> and contributors
+All rights reserved.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Arne Blankerts nor the names of contributors
+  may be used to endorse or promote products derived from this software
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT  * NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/src/ConfiguredMediator.php
+++ b/src/ConfiguredMediator.php
@@ -7,15 +7,22 @@ namespace PharIo\ComposerDistributor;
 use Composer\Composer;
 use Composer\Installer\PackageEvent;
 use Composer\IO\IOInterface;
+use Exception;
+use GnuPG;
 use PharIo\ComposerDistributor\Config\Config;
 use PharIo\ComposerDistributor\Config\Loader;
 use PharIo\ComposerDistributor\Service\Installer;
+use PharIo\FileSystem\Directory;
+use PharIo\GnuPG\Factory;
 use SplFileInfo;
 
 abstract class ConfiguredMediator extends PluginBase
 {
     /** @var \PharIo\ComposerDistributor\Config\Config */
     private $config;
+
+    /** @var bool  */
+    private static $warningDisplayed = false;
 
     /**
      * Config has to be loaded on instantiation because on uninstall all external dependencies are
@@ -37,15 +44,43 @@ abstract class ConfiguredMediator extends PluginBase
 
     public function installOrUpdateFunction(PackageEvent $event): void
     {
+        $gnuPG = $this->createGnuPG();
+        // we do not want to crash if no GnuPG was found
+        // but display a noticeable warning to the user
+        if (null === $gnuPG && !self::$warningDisplayed) {
+            $this->io->write(
+                PHP_EOL .
+                '    <warning>WARNING</warning>' . PHP_EOL .
+                '    No GPG installation found! Use installed PHARs with care. ' . PHP_EOL .
+                '    Consider installing GnuPG to verify PHAR authenticity.' . PHP_EOL .
+                '    If you need help installing GnuPG visit http://phar.io/install-gnupg' . PHP_EOL
+            );
+            self::$warningDisplayed = true;
+        }
+
         $installer = $this->createInstallerFromConfig($this->config, $event);
-        $installer->install($this->config->phars());
+        $installer->install(
+            $this->config->phars(),
+            $this->config->keyDirectory() ? $this->createKeyDirectory($this->config) : null,
+            $gnuPG
+        );
+    }
+
+    public function createGnuPG(): ?GnuPG
+    {
+        $factory = new Factory();
+        try {
+            $gnuPG = $factory->createGnuPG(new Directory(sys_get_temp_dir()));
+        } catch (Exception $e) {
+            $gnuPG = null;
+        }
+        return $gnuPG;
     }
 
     private function createInstallerFromConfig(Config $config, PackageEvent $event): Installer
     {
         return new Installer(
             $config->package(),
-            $config->keyDirectory() ? $this->createKeyDirectory($config) : null,
             $this->io,
             $event
         );
@@ -86,7 +121,7 @@ abstract class ConfiguredMediator extends PluginBase
                 );
                 return;
             }
-            $this->io->write(sprintf('  - Removing phar \'%1$s\'', $phar->pharName()));
+            $this->io->write(sprintf('  - Removing phar <info>%1$s</info>', $phar->pharName()));
             unlink($pharLocation);
         }
     }

--- a/src/ConfiguredMediator.php
+++ b/src/ConfiguredMediator.php
@@ -21,9 +21,6 @@ abstract class ConfiguredMediator extends PluginBase
     /** @var \PharIo\ComposerDistributor\Config\Config */
     private $config;
 
-    /** @var bool  */
-    private static $warningDisplayed = false;
-
     /**
      * Config has to be loaded on instantiation because on uninstall all external dependencies are
      * removed before `uninstall` is called and auto-loading any external phar-io dependencies then will fail.
@@ -47,7 +44,7 @@ abstract class ConfiguredMediator extends PluginBase
         $gnuPG = $this->createGnuPG();
         // we do not want to crash if no GnuPG was found
         // but display a noticeable warning to the user
-        if (null === $gnuPG && !self::$warningDisplayed) {
+        if ($gnuPG === null) {
             $this->io->write(
                 PHP_EOL .
                 '    <warning>WARNING</warning>' . PHP_EOL .
@@ -55,7 +52,6 @@ abstract class ConfiguredMediator extends PluginBase
                 '    Consider installing GnuPG to verify PHAR authenticity.' . PHP_EOL .
                 '    If you need help installing GnuPG visit http://phar.io/install-gnupg' . PHP_EOL
             );
-            self::$warningDisplayed = true;
         }
 
         $installer = $this->createInstallerFromConfig($this->config, $event);

--- a/src/ConfiguredMediator.php
+++ b/src/ConfiguredMediator.php
@@ -34,8 +34,7 @@ abstract class ConfiguredMediator extends PluginBase
 
     public function uninstall(Composer $composer, IOInterface $io)
     {
-        $this->composer = $composer;
-        $this->io       = $io;
+        parent::uninstall($composer, $io);
         $this->removePhars();
     }
 
@@ -45,7 +44,7 @@ abstract class ConfiguredMediator extends PluginBase
         // we do not want to crash if no GnuPG was found
         // but display a noticeable warning to the user
         if ($gnuPG === null) {
-            $this->io->write(
+            $this->getIO()->write(
                 PHP_EOL .
                 '    <warning>WARNING</warning>' . PHP_EOL .
                 '    No GPG installation found! Use installed PHARs with care. ' . PHP_EOL .
@@ -77,7 +76,7 @@ abstract class ConfiguredMediator extends PluginBase
     {
         return new Installer(
             $config->package(),
-            $this->io,
+            $this->getIO(),
             $event
         );
     }
@@ -99,7 +98,7 @@ abstract class ConfiguredMediator extends PluginBase
 
     private function removePhars(): void
     {
-        $binDir = $this->composer->getConfig()->get('bin-dir');
+        $binDir = $this->getComposer()->getConfig()->get('bin-dir');
 
         foreach ($this->config->phars()->getList() as $phar) {
             $this->deleteFile($phar, $binDir);
@@ -112,12 +111,12 @@ abstract class ConfiguredMediator extends PluginBase
 
         if (is_file($pharLocation)) {
             if (!is_writable($pharLocation)) {
-                $this->io->write(
+                $this->getIO()->write(
                     sprintf('  - Can not remove phar \'%1$s\' (insufficient permissions)', $phar->pharName())
                 );
                 return;
             }
-            $this->io->write(sprintf('  - Removing phar <info>%1$s</info>', $phar->pharName()));
+            $this->getIO()->write(sprintf('  - Removing phar <info>%1$s</info>', $phar->pharName()));
             unlink($pharLocation);
         }
     }

--- a/src/PluginBase.php
+++ b/src/PluginBase.php
@@ -11,30 +11,31 @@ use Composer\Installer\PackageEvents;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
 use PharIo\ComposerDistributor\Service\Installer;
-use SplFileInfo;
 
 abstract class PluginBase implements PluginInterface, EventSubscriberInterface
 {
+    /** @var \Composer\Composer */
     protected $composer;
 
+    /** @var \Composer\IO\IOInterface */
     protected $io;
 
     public function activate(Composer $composer, IOInterface $io)
     {
         $this->composer = $composer;
-        $this->io = $io;
+        $this->io       = $io;
     }
 
     public function deactivate(Composer $composer, IOInterface $io)
     {
         $this->composer = $composer;
-        $this->io = $io;
+        $this->io       = $io;
     }
 
     public function uninstall(Composer $composer, IOInterface $io)
     {
         $this->composer = $composer;
-        $this->io = $io;
+        $this->io       = $io;
     }
 
     public static function getSubscribedEvents()
@@ -43,17 +44,16 @@ abstract class PluginBase implements PluginInterface, EventSubscriberInterface
             PackageEvents::POST_PACKAGE_INSTALL => [
                 ['installOrUpdateFunction', 0],
             ],
-            PackageEvents::POST_PACKAGE_UPDATE => [
+            PackageEvents::POST_PACKAGE_UPDATE  => [
                 ['installOrUpdateFunction', 0],
             ],
         ];
     }
 
-    public function createInstaller(string $pluginName, string $keyDirectory, PackageEvent $event) : Installer
+    public function createInstaller(string $pluginName, PackageEvent $event) : Installer
     {
         return new Installer(
             $pluginName,
-            new KeyDirectory(new SplFileInfo($keyDirectory)),
             $this->io,
             $event
         );

--- a/src/PluginBase.php
+++ b/src/PluginBase.php
@@ -15,10 +15,12 @@ use PharIo\ComposerDistributor\Service\Installer;
 abstract class PluginBase implements PluginInterface, EventSubscriberInterface
 {
     /** @var \Composer\Composer */
-    protected $composer;
+    private $composer;
 
     /** @var \Composer\IO\IOInterface */
-    protected $io;
+    private $io;
+
+    abstract public function installOrUpdateFunction(PackageEvent $event) : void;
 
     public function activate(Composer $composer, IOInterface $io)
     {
@@ -59,5 +61,19 @@ abstract class PluginBase implements PluginInterface, EventSubscriberInterface
         );
     }
 
-    abstract public function installOrUpdateFunction(PackageEvent $event) : void;
+    protected function getIO(): IOInterface
+    {
+        if (!$this->io) {
+            throw new \RuntimeException('IO not set');
+        }
+        return $this->io;
+    }
+
+    protected function getComposer(): Composer
+    {
+        if (!$this->composer) {
+            throw new \RuntimeException('Composer not set');
+        }
+        return $this->composer;
+    }
 }

--- a/src/Service/Installer.php
+++ b/src/Service/Installer.php
@@ -86,7 +86,7 @@ final class Installer
             return $pharLocation;
         }
 
-        if (null === $this->gpg) {
+        if ($this->gpg === null) {
             $this->io->write('  - <comment>No GnuPG found to verify signature! Use this file with care!</comment>');
             return $pharLocation;
         }
@@ -122,7 +122,7 @@ final class Installer
 
     private function verifyPharWithSignature(SplFileInfo $pharLocation, SplFileInfo $signatureLocation): void
     {
-        if (null === $this->keys) {
+        if ($this->keys === null) {
             throw new RuntimeException('No keys to verify the signature');
         }
 


### PR DESCRIPTION
Output without GnuPG

```
$ composer require --dev captainhook/captainhook-phar
Using version ^5.4 for captainhook/captainhook-phar
./composer.json has been updated
Running composer update captainhook/captainhook-phar
Loading composer repositories with package information
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking captainhook/captainhook-phar (5.4.3)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Installing captainhook/captainhook-phar (5.4.3): Extracting archive

    WARNING
    No GPG installation found! Use installed PHARs with care.
    Consider installing GnuPG to verify PHAR authenticity.
    If you need help installing GnuPG visit http://phar.io/install-gnupg

  - Downloading artifact from https://github.com/captainhookphp/captainhook/releases/download/5.4.3/captainhook.phar
  - No GnuPG found to verify signature! Use this file with care!
Generating autoload files
2 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

Uninstall output

```
$ composer update
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 0 updates, 1 removal
  - Removing captainhook/captainhook-phar (5.4.3)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 0 updates, 1 removal
  - Removing phar captainhook
  - Removing captainhook/captainhook-phar (5.4.3)
Generating autoload files
1 package you are using is looking for funding.
Use the `composer fund` command to find out more!
```

TODO:
Setup  http://phar.io/install-gnupg with some basic hints on how to install GnuPG