### PR TITLE
Seperate OperationPackage to validate the PackageEvent is for the configured package

### DIFF
--- a/src/ConfiguredMediator.php
+++ b/src/ConfiguredMediator.php
@@ -40,6 +40,9 @@ abstract class ConfiguredMediator extends PluginBase
 
     public function installOrUpdateFunction(PackageEvent $event): void
     {
+        if (!$this->isDesiredPackageEvent($event, $this->config->package())) {
+            return;
+        }
         $gnuPG = $this->createGnuPG();
         // we do not want to crash if no GnuPG was found
         // but display a noticeable warning to the user

--- a/src/OperationPackage.php
+++ b/src/OperationPackage.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types = 1);
+namespace PharIo\ComposerDistributor;
+
+use Composer\Composer;
+use Composer\DependencyResolver\GenericRule;
+use Composer\DependencyResolver\Operation\InstallOperation;
+use Composer\DependencyResolver\Operation\UninstallOperation;
+use Composer\DependencyResolver\Operation\UpdateOperation;
+use Composer\Installer\PackageEvent;
+use Composer\Package\CompletePackage;
+use Composer\Package\Package;
+use Composer\Semver\Constraint\MultiConstraint;
+use RuntimeException;
+
+class OperationPackage {
+
+    public static function createFromEvent(PackageEvent $event, string $pluginName): Package
+    {
+        if (0 >= \version_compare('2.0.0', Composer::VERSION)) {
+            $operation = $event->getOperation();
+
+            switch (true) {
+                case $operation instanceof InstallOperation:
+                case $operation instanceof UninstallOperation:
+                    $package = $operation->getPackage();
+
+                    break;
+                case $operation instanceof UpdateOperation:
+                    $package = $operation->getTargetPackage();
+
+                    break;
+                default:
+                    throw new RuntimeException('No valid operation found');
+            }
+        } else {
+            /** @var GenericRule $rule */
+            $rule = $event->getOperation()->getReason();
+            /** @var MultiConstraint $constraint */
+            $constraint = $rule->getJob()['constraint'];
+
+            if ($rule->getRequiredPackage() !== $pluginName) {
+                throw SomebodyElsesProblem::here($pluginName);
+            }
+
+            /** @var CompletePackage $packages */
+            $package = $event->getInstalledRepo()->findPackage($rule->getRequiredPackage(), $constraint->getPrettyString());
+        }
+
+        return $package;
+    }
+}

--- a/src/PackageVersion.php
+++ b/src/PackageVersion.php
@@ -91,32 +91,7 @@ final class PackageVersion
 
     public static function fromPackageEvent(PackageEvent $event, string $pluginName) : self
     {
-        $package = null;
-        if (0 >= version_compare('2.0.0', Composer::VERSION)) {
-            $operation = $event->getOperation();
-            switch (true) {
-                case $operation instanceof InstallOperation:
-                case $operation instanceof UninstallOperation:
-                    $package = $operation->getPackage();
-                    break;
-                case $operation instanceof UpdateOperation:
-                    $package = $operation->getTargetPackage();
-                    break;
-                default:
-                    throw new RuntimeException('No valid operation found');
-            }
-        } else {
-            /** @var GenericRule $rule */
-            $rule = $event->getOperation()->getReason();
-            /** @var MultiConstraint $constraint */
-            $constraint = $rule->getJob()['constraint'];
-            if ($rule->getRequiredPackage() !== $pluginName) {
-                throw SomebodyElsesProblem::here($pluginName);
-            }
-
-            /** @var CompletePackage $packages */
-            $package = $event->getInstalledRepo()->findPackage($rule->getRequiredPackage(), $constraint->getPrettyString());
-        }
+        $package = OperationPackage::createFromEvent($event, $pluginName);
         return new self($package->getName(), $package->getFullPrettyVersion());
     }
 }

--- a/src/PluginBase.php
+++ b/src/PluginBase.php
@@ -76,4 +76,11 @@ abstract class PluginBase implements PluginInterface, EventSubscriberInterface
         }
         return $this->composer;
     }
+
+    protected function isDesiredPackageEvent(PackageEvent $event, string $pluginName): bool
+    {
+        $package = OperationPackage::createFromEvent($event, $pluginName);
+
+        return $package->getName() === $pluginName;
+    }
 }


### PR DESCRIPTION
Hey,

i tested some with the `captainhook/captainhook-phar` and noticed a bug with a fresh install with multiple packages.

For example i have the following composer.json and nothing elese.
```
  "require": {
    "captainhook/captainhook-phar": "5.8.0",
    "aws/aws-sdk-php": "3.175.3"
  }
```

after a `composer install` i noticed multiple file downloads with the wrong version.

Every(?) packages will trigger the `installOrUpdateFunction` Event and try to install captainhook in the version of the other Package. 

In this merge request i seperated the Composer V2 and Composer V1 logic into a `OperationPackage` to use it in the PackageVersion and the ConfiguredMediator.
I tried to run the cs-fixer, but the cs-fixer will change a lot. So i skipped the cs-fixer.


For now every configured package has to use the same `packageName` in the `distributor.xml` as the composer package name. 
If the name differs, the hook is not triggerd and no installation would be made.


In my example, with Captainhook a seperate fix is required to change the package name from `packageName="captainhook/captainhook"` to `packageName="captainhook/captainhook-phar"` in the distributor.xml