### PR TITLE
Fix bugs and add missing no_proxy in Download.php

### DIFF
--- a/src/Service/Download.php
+++ b/src/Service/Download.php
@@ -5,11 +5,21 @@ declare(strict_types=1);
 namespace PharIo\ComposerDistributor\Service;
 
 use PharIo\ComposerDistributor\Url;
+use RuntimeException;
 use SplFileInfo;
+use function explode;
+use function fclose;
 use function feof;
+use function fopen;
+use function fread;
 use function fwrite;
 use function getenv;
+use function ltrim;
+use function parse_url;
+use function preg_replace;
 use function stream_context_create;
+use function strtolower;
+use function trim;
 
 final class Download
 {
@@ -22,31 +32,51 @@ final class Download
 
     public function toLocation(SplFileInfo $downloadLocation) : void
     {
-        $context = $this->getStreamContext();
-        $source = fopen($this->url->toString(), 'r',false, $context);
-        $target = fopen($downloadLocation->getPathname(), 'w');
-        while (!feof($source)) {
-            fwrite($target, fread($source, 1024));
+        $context = $this->getStreamContext($this->url->toString());
+        $source = @fopen($this->url->toString(), 'r',false, $context);
+        if ($source === false) {
+            throw new RuntimeException(
+                'Failed to open download source: ' . $this->url->toString()
+            );
         }
-        fclose($source);
-        fclose($target);
+
+        $target = @fopen($downloadLocation->getPathname(), 'w');
+        if ($target === false) {
+            fclose($source);
+            throw new RuntimeException(
+                'Failed to open download target: ' . $downloadLocation->getPathname()
+            );
+        }
+
+        try {
+            while (!feof($source)) {
+                $chunk = fread($source, 1024);
+                if ($chunk === false) {
+                    throw new RuntimeException(
+                        'Failed to read from download source: ' . $this->url->toString()
+                    );
+                }
+                fwrite($target, $chunk);
+            }
+        } finally {
+            fclose($source);
+            fclose($target);
+        }
     }
 
     /**
      * @return resource
      */
-    private function getStreamContext()
+    private function getStreamContext(string $targetUrl)
     {
-        foreach (['http_proxy', 'HTTP_PROXY', 'https_proxy', 'HTTPS_PROXY'] as $envName) {
-            $proxy = getenv($envName);
-            if ($proxy !== '') {
-                break;
-            }
-        }
+        $proxy = $this->resolveProxyForUrl($targetUrl);
 
-        if ($proxy === '') {
+        if (empty($proxy)) {
             return stream_context_create([]);
         }
+
+        $proxy = preg_replace('#^https://#i', 'tls://', $proxy);
+        $proxy = preg_replace('#^http://#i', 'tcp://', $proxy);
 
         $context = [
             'http' => [
@@ -55,11 +85,78 @@ final class Download
             ]
         ];
 
+        if (str_starts_with($proxy, 'tls://')) {
+            $context['ssl'] = [
+                'SNI_enabled' => true,
+            ];
+        }
+
         $auth = getenv('HTTP_PROXY_AUTH');
-        if ($auth !== '') {
+        if (!empty($auth)) {
             $context['http']['header'][] = 'Proxy-Authorization: Basic ' . $auth;
         }
 
         return stream_context_create($context);
+    }
+
+    private function resolveProxyForUrl(string $targetUrl): ?string
+    {
+        $isHttps = strncasecmp($targetUrl, 'https://', 8) === 0;
+
+        $candidates = $isHttps
+            ? ['https_proxy', 'HTTPS_PROXY', 'http_proxy', 'HTTP_PROXY']
+            : ['http_proxy', 'HTTP_PROXY'];
+
+        $proxy = '';
+        foreach ($candidates as $envName) {
+            $proxy = getenv($envName);
+            if (!empty($proxy)) {
+                break;
+            }
+        }
+
+        if (empty($proxy)) {
+            return null;
+        }
+
+        if ($this->urlMatchesNoProxy($targetUrl)) {
+            return null;
+        }
+
+        return $proxy;
+    }
+
+    private function urlMatchesNoProxy(string $targetUrl): bool
+    {
+        $noProxy = getenv('no_proxy');
+        if (empty($noProxy)) {
+            $noProxy = getenv('NO_PROXY');
+        }
+        if (empty($noProxy)) {
+            return false;
+        }
+
+        $host = parse_url($targetUrl, PHP_URL_HOST);
+        if (empty($host)) {
+            return false;
+        }
+        $host = strtolower($host);
+
+        foreach (explode(',', $noProxy) as $entry) {
+            $entry = strtolower(trim($entry));
+            if ($entry === '') {
+                continue;
+            }
+            if ($entry === '*') {
+                return true;
+            }
+
+            $entry = ltrim($entry, '.');
+            if ($host === $entry || substr($host, -strlen('.' . $entry)) === '.' . $entry) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Hi, 
I noticed several issues with the Download.php as I tried debugging a failing download. I found a couple of issues in combination with HTTP_PROXY:
1. wrong return type assumption for getenv, the original code assumed the output to be an empty string, not false. This results in the loop always breaking after http_proxy, missing the other headers, and also appending the context with an invalid value
3. the code would fail if the url starts with http:// or https:// instead of tcp:// or tls:// transport schemes
4. missing support for no_proxy

I took the time to also review some other potential issues like missing return type checks. 

Please note that I tried adding support for proxies that are served with https but could not verify if they work because I do not have a proxy served using https at hand. I still decided to add it, as I consider it to be an improvement to the status quo, but if you want a comment added for this or instead want to throw an error, please let me know.

I hope this can be of use.

Best regards